### PR TITLE
Fix SAN elements submission

### DIFF
--- a/requests/client.go
+++ b/requests/client.go
@@ -102,6 +102,7 @@ func (c *Client) DecentralizedEnroll(profile string, csr []byte, labels []LabelE
 	// Translate the parsed certificate SAN elements into the request elements
 	var sans []IndexedSANElement
 	for _, sanElement := range parsedCsr.Sans {
+		typeCounts[sanElement.SanType]++
 		sans = append(sans, IndexedSANElement{
 			Element: fmt.Sprintf("%s.%d", strings.ToLower(sanElement.SanType), typeCounts[sanElement.SanType]),
 			Type:    sanElement.SanType,


### PR DESCRIPTION
When submitting a CSR with multiple SANs elements, the SAN element name would not get incremented and thus override the first element. This is now fixed.