### PR TITLE
Fetch trustchain for a certificate

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,25 +1,35 @@
 # Go Horizon
 
-The official Go SDK for Horizon. 
+The official Go SDK for Horizon.
 
 ## Installation
 
 With the Go module system, just reference this module anywhere in your code :
+
 ```go
 import (
-	"github.com/evertrust/horizon-go
+"github.com/evertrust/horizon-go
 )
 ```
 
-You can also explicitely require the package in your existing project using `go get` : 
+You can also explicitly require the package in your existing project using `go get` :
+
 ```shell
 go get -u "github.com/evertrust/horizon-go"
 ```
 
+## Breaking changes policy
 
-## Compatibility matrix
+The `horizon-go` project follows the semver conventions, meaning that once 1.y.z is reached, y and z versions will not
+introduce any breaking changes. In the meantime, the API will mostly remain backwards-compatible but may break from time
+to time.
+
+When using a recent SDK version with an older Horizon version, you may encounter `NotImplementedError`s, which
+indicates that the feature you're trying to use is not available on the targeted Horizon instance. The following
+compatibility matrix provides you with what SDK versions have been tested against which Horizon versions :
 
 | SDK version | Horizon version |
-|-------------|-----------------|
-| 0.0.1       | >= 2.1.0        |
-| 0.0.2       | >= 2.2.0        |
+|-------------|-----------|
+| 0.0.1 | >= 2.1.0 |
+| 0.0.2 | >= 2.2.0 |
+| 0.0.4 | >= 2.2.2 |

--- a/http/client.go
+++ b/http/client.go
@@ -110,6 +110,8 @@ func (c *Client) Post(path string, body []byte) (response *HorizonResponse, err 
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	req.Header.Add("x-api-id", c.apiId)
 	req.Header.Add("x-api-key", c.apiKey)
+	// Always prefer JSON responses
+	req.Header.Add("Accept", "application/json")
 	return c.baseClient.Do(req)
 }
 

--- a/http/errors.go
+++ b/http/errors.go
@@ -15,3 +15,26 @@ func (e *HorizonErrorResponse) Error() string {
 	}
 	return msg
 }
+
+type Feature int
+
+const (
+	TrustchainDecoding Feature = iota
+)
+
+func (feature Feature) String() string {
+	switch feature {
+	case TrustchainDecoding:
+		return "trustchains decoding"
+	}
+	return "unknown feature"
+}
+
+type NotImplementedError struct {
+	Feature       Feature `json:"feature"`
+	ImplementedIn string  `json:"implementedIn"`
+}
+
+func (e *NotImplementedError) Error() string {
+	return fmt.Sprintf("The current Horizon version doesn't support this feature (%s). Please upgrade the instance to a version >= %s", e.Feature.String(), e.ImplementedIn)
+}

--- a/http/response.go
+++ b/http/response.go
@@ -2,13 +2,27 @@ package http
 
 import (
 	"encoding/json"
+	"mime"
 	"net/http"
+	"strings"
 )
 
 type HorizonResponse struct {
 	BaseResponse *http.Response
 }
 
+func (r *HorizonResponse) HasContentType(mimeType string) bool {
+	for _, v := range strings.Split(r.BaseResponse.Header.Get("Content-Type"), ",") {
+		t, _, err := mime.ParseMediaType(v)
+		if err != nil {
+			break
+		}
+		if t == mimeType {
+			return true
+		}
+	}
+	return false
+}
 func (r *HorizonResponse) Json() *json.Decoder {
 	return json.NewDecoder(r.BaseResponse.Body)
 }

--- a/rfc5280/client.go
+++ b/rfc5280/client.go
@@ -60,6 +60,13 @@ func (c *Client) Trustchain(cert []byte, order TrustchainOrder) ([]CfCertificate
 		return nil, err
 	}
 
+	if response.HasContentType("text/plain") {
+		return nil, &http.NotImplementedError{
+			Feature:       http.TrustchainDecoding,
+			ImplementedIn: "2.2.2",
+		}
+	}
+
 	var trustchain []CfCertificate
 	err = response.Json().Decode(&trustchain)
 	if err != nil {

--- a/rfc5280/client.go
+++ b/rfc5280/client.go
@@ -38,3 +38,32 @@ func (c *Client) Pkcs10(pkcs10 []byte) (*CFCertificationRequest, error) {
 	}
 	return &csr, nil
 }
+
+// Trustchain takes an X509 certificate and returns a collection of CfCertificate objects,
+// in the order given by TrustchainOrder.
+func (c *Client) Trustchain(cert []byte, order TrustchainOrder) ([]CfCertificate, error) {
+	baseUrl := c.Http.BaseUrl()
+	encodedCert := url.PathEscape(string(cert))
+	reqUrl := baseUrl.String() + "/api/v1/rfc5280/tc/" + encodedCert + "?order=" + order.String()
+	req, err := baseHttp.NewRequest("GET", reqUrl, nil)
+
+	if err != nil {
+		return nil, err
+	}
+	baseResponse, err := c.Http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := c.Http.Unmarshal(baseResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	var trustchain []CfCertificate
+	err = response.Json().Decode(&trustchain)
+	if err != nil {
+		return nil, err
+	}
+	return trustchain, nil
+}

--- a/rfc5280/rfc5280.go
+++ b/rfc5280/rfc5280.go
@@ -18,3 +18,40 @@ type CFCertificationRequest struct {
 	KeyType    string                 `json:"keyType"`
 	Pem        string                 `json:"pem"`
 }
+
+type CfCertificate struct {
+	Dn               string                 `json:"dn"`
+	Sans             []SubjectAlternateName `json:"sans"`
+	DnElements       []CFDistinguishedName  `json:"dnElements"`
+	KeyType          string                 `json:"keyType"`
+	SigningAlgorithm string                 `json:"signingAlgorithm"`
+	Pem              string                 `json:"pem"`
+	Serial           string                 `json:"serial"`
+	IssuerDn         string                 `json:"issuerDn"`
+	NotBefore        int                    `json:"notBefore"`
+	NotAfter         int                    `json:"notAfter"`
+	SelfSigned       bool                   `json:"selfSigned"`
+}
+
+type TrustchainOrder int
+
+const (
+	RootToLeaf TrustchainOrder = iota
+	LeafToRoot
+	IssuingRootToLeaf
+	IssuingLeafToRoot
+)
+
+func (order TrustchainOrder) String() string {
+	switch order {
+	case RootToLeaf:
+		return "rtl"
+	case LeafToRoot:
+		return "ltr"
+	case IssuingRootToLeaf:
+		return "irtl"
+	case IssuingLeafToRoot:
+		return "iltr"
+	}
+	return ""
+}


### PR DESCRIPTION
This PR implements a new `Trustchain` method allowing, for a given certificate, to fetch the related trust chain to the best knowledge of Horizon. 